### PR TITLE
Add command line args to logwatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+error_log*

--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ LogWatcherBlue.sh is meant to run as a cron job within cPanel on a webhost.  If 
 The principle difference between LogWatcher.sh and LogWatcherBlue.sh is that LogWatcher requires an SSH login and it requries SMTP to be pre-configured.  LogWatcherBlue assumes direct access to the error log and it uses the webhost's settings to send an email using a terminal utility called mailx.  Of course if you used your cell carriers SMS gateway you could have text alerts.
 
 Both LogWatcher.sh and LogWatcherBlue.sh will require you to configure your SSH access and the paths to your error_log file.
+
+## Usage
+
+```bash
+❯ ./logwatcher.sh
+
+    Usage: ./logwatcher.sh [-u] [-r] [-f] [-l] [-e]
+
+    Example: ./logwatcher.sh -u my_user -r my_server.my_domain.com -f /path/to/remote/file -l /path/to/local/file -e myself@me.com
+```

--- a/logwatcher.sh
+++ b/logwatcher.sh
@@ -7,7 +7,7 @@
 log_file=error_log
 
 # rename the source file
-# if the source file does not exist a warning is displayed, but the script will keep processing just fine.
+# if the source file does not exist, create it
 create_file(){
   if [ ! -f $log_file ]; then
     touch error_log

--- a/logwatcher.sh
+++ b/logwatcher.sh
@@ -1,25 +1,92 @@
-#!/bin/bash
-# v.1; GNU GPL
+#!/usr/bin/env bash
+# v0.2; GNU GPL
 # Written by Kyle Pott
 # Download a log file and check if it has changed.
 # If it has changed then send an email.
 # Pre-reqs: access SSH access, ssmtp installed and configured
+log_file=error_log
 
 # rename the source file
 # if the source file does not exist a warning is displayed, but the script will keep processing just fine.
-touch error_log
-cp error_log error_log_source
+create_file(){
+  if [ ! -f $log_file ]; then
+    touch error_log
+  fi
+  cp error_log error_log_source
+}
 
 # download the file.  This can be done regularly be scheduling this script as a cron job
 # as a security precaution the log file should not be available over the open internet.
 # You can use an .htaccess file to make sure open internet access is restricted.
 # In order to fully automate the authentication process you can follow this guide: liuxproblem.org/art_9.html
-scp yourSSHaccount@yourdomain.com:~/public_html/path/to/file ~/path/to/where/you/want/to/compare/file
+scp_file(){
+ scp ${user}@${remote_host}:${remote_file} ${local_file}
+}
 
 # comparison logic
 # https://stackoverflow.com/questions/8139885/shellscript-action-if-two-files-are-different
-if ! cmp error_log error_log_source > /dev/null 2>&1
-then 
-# email logic
-echo "new login detected $(date)" | ssmtp youremailaddress@email.com
+compare_file(){
+  if ! cmp error_log error_log_source > /dev/null 2>&1; then
+    # email logic
+    echo "new login detected $(date)" | ssmtp ${email_address}
+  fi
+}
+
+# print example usage
+usage(){
+# sample colors to use
+red="tput setaf 1"
+green="tput setaf 2"
+yellow="tput setaf 3"
+reset="tput sgr0"
+
+# change output color to green
+$green
+
+echo "
+    Usage: $0 [-u] [-r] [-f] [-l] [-e]
+
+    Example: ./logwatcher.sh -u my_user -r my_server.my_domain.com -f /path/to/remote/file -l /path/to/local/file -e myself@me.com
+    "
+
+# switch back to default output color
+$reset
+}
+
+#################
+# Script Begins #
+#################
+while getopts ":u:r:f:l:e:" opt; do
+  case ${opt} in
+    u ) # user
+        user=${OPTARG}
+        ;;
+    r ) # remote host
+        remote_host=${OPTARG}
+        ;;
+    f ) # remote file
+        remote_file=${OPTARG}
+        ;;
+    l ) # local file
+        local_file=${OPTARG}
+        ;;
+    e ) # email address
+        email_address=${OPTARG}
+        ;;
+        # help if -h or no opts passed
+    h | ?) usage
+      ;;
+  esac
+done
+
+# discard unidentified args from arg list
+shift "$((OPTIND-1))"
+
+# ensure all opts are set
+if [[ -z "${user}" || -z "${remote_host}" || -z "${remote_file}" || -z "${local_file}" || -z "${email_address}" ]]; then
+  usage
+else
+  create_file
+  scp_file
+  compare_file
 fi


### PR DESCRIPTION
- Changed shebang to use bash on the $PATH instead of hard requirement of `#!/bin/bash`
- Broke out logic into functions
- Added command line arguments
  - With colored output, because it looks cool
- Added executable permissions to `logwatcher.sh` by running `chmod+x` on the file
- Added `error_log*` file pattern to `.gitignore` to prevent accidental committing of those files
- Added logic to test if files existed and only create if not present
- Add sample usage to `README.md`

Cool project. I left `logwatcherblue.sh` alone in case you wanted to add some of these options to it. It's fun to get hands dirty :smile: 


